### PR TITLE
Added deploy to S3, will restrict to master branch if this build succeeds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,16 @@ script:
 - rake test
 env:
   global:
-  - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer
+  - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+deploy:
+  provider: s3
+  access_key_id: AKIAJUHCKKZCTVJQGOXA
+  secret_access_key:
+    secure: JqgqPebaI6aoplctpz3y6baGbi9PEjv8MLZWb/fXPWIWmq1jHfU/mLM5gUAT0N41qqcKT9JtrUD5ybG8EyKaczt/z5CHUR+K0DkVVc0wiKiM5+Ow+XAK40ZamZj+pRgHy8hhPLqcVjuZp1DEzM6MgfJ7RQ7n7AJXbdRlal511Ug=
+  bucket: www.jacobtomlinson.co.uk
+  local-dir: _site
+  acl: public_read
+  skip_cleanup: true
+  region: eu-west-1
+  on:
+    repo: jacobtomlinson/jacobtomlinson.github.io

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,5 @@ deploy:
   region: eu-west-1
   on:
     repo: jacobtomlinson/jacobtomlinson.github.io
-    branch: s3-deploy
+    branch: master
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,4 @@ deploy:
   region: eu-west-1
   on:
     repo: jacobtomlinson/jacobtomlinson.github.io
+    branch: s3-deploy

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -13,7 +13,7 @@
       <a href="{{ site.google_plus_link }}" target="_new"><i class="fa fa-google-plus"></i></a>
       <a href="https://github.com/{{ site.github_username }}" target="_new"><i class="fa fa-github-alt"></i></a>
       <a href="{{ site.stackoverflow_link }}" target="_new"><i class="fa fa-stack-overflow"></i></a>
-      <a href="http://www.jacobtomlinson.co.uk/feed" target="_new"><i class="fa fa-rss"></i></a>
+      <a href="http://www.jacobtomlinson.co.uk/feed.xml" target="_new"><i class="fa fa-rss"></i></a>
     </p>
   </div>
 </nav>

--- a/_posts/2014/2014-04-25-nasa-space-apps-challenge-2014-roundup.md
+++ b/_posts/2014/2014-04-25-nasa-space-apps-challenge-2014-roundup.md
@@ -41,11 +41,11 @@ I am very grateful for the excellent team I worked with but I am especially than
 
 ![Space Apps Teams](http://i.imgur.com/sMO2e2M.png)
 
-#### Most of <a title="Asteroid Prospector Credits" href="http://jacobtomlinson.github.io/asteroid-prospector/credits.html" target="_blank">the team</a>. Photo by <a title="Adam Burt's Flickr" href="https://www.flickr.com/photos/aburt/" target="_blank">Adam Burt</a>
+#### Most of <a title="Asteroid Prospector Credits" href="http://www.ape-mining.com//credits.html" target="_blank">the team</a>. Photo by <a title="Adam Burt's Flickr" href="https://www.flickr.com/photos/aburt/" target="_blank">Adam Burt</a>
 
 For more information on the project see the following resources:
 
-*   <a title="Play Asteroid Prospector" href="http://jacobtomlinson.github.io/asteroid-prospector/" target="_blank">The game itself</a>
+*   <a title="Play Asteroid Prospector" href="http://www.ape-mining.com/" target="_blank">The game itself</a>
 *   <a title="Asteroid Prospector Twitter" href="https://twitter.com/APEMining" target="_blank">Twitter</a>
 *   <a title="Asteroid Prospector Tumblr" href="http://asteroidprospectorexeter.tumblr.com/" target="_blank">Tumblr</a>
 *   <a title="Asteroid Prospector GitHub" href="https://github.com/jacobtomlinson/asteroid-prospector/tree/gh-pages" target="_blank">GitHub</a>


### PR DESCRIPTION
I'm starting to find GitHub a little restricting. I would like to start using bower to manage dependancies and also start playing with Jekyll plugins.

I'm getting Travis to deploy to S3 on commits to the master branch. This means I have total control over the builds on Travis and will only pay a small price for the bandwidth on S3, especially if I pair it with a free CDN service.